### PR TITLE
Simplify action invocation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: DeterminateSystems/nix-installer-action@main
-        with:
-          # Allow the installed Nix to make authenticated Github requests.
-          # If you skip this, you will likely get rate limited.
-          github-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v3
       - run: nix flake check
       - run: nix run


### PR DESCRIPTION
by removing the explicit value for `github-token` and instead leveraging
the default.