### PR TITLE
Remove explicit github-token setting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: DeterminateSystems/nix-installer-action@main
-        with:
-          # Allow the installed Nix to make authenticated Github requests.
-          # If you skip this, you will likely get rate limited.
-          github-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v3
       - run: nix flake check
       - run: nix run


### PR DESCRIPTION
This setting is now the default and thus not really necessary in this example.
